### PR TITLE
Refactor manage_league

### DIFF
--- a/sh_app/templates/manage_league.html
+++ b/sh_app/templates/manage_league.html
@@ -16,36 +16,28 @@ head_official: HO of the league
     <h1>Officials</h1>
     <ul>
     {% for sh_user in list_of_officials %}
-    {% if sh_user == head_official and forloop.last %}
-        <li>{{ league }} has no officials</li>
-    {% else %}
-    {% if sh_user != head_official %}
         <li> {{ sh_user }}
             <form id="demote_form" method="POST" action="{% url "manage_league" league.id %}">
             {% csrf_token %}
             <input type="submit" name="demote_{{ sh_user.id }}" value="Demote"/>
             </form>
         </li>
-    {% endif %}
-    {% endif %}
+    {% empty %}
+        <li>{{ league }} has no officials</li>
     {% endfor %}
     </ul>
 
     <h1>Members</h1>
     <ul>
     {% for sh_user in list_of_members %}
-    {% if sh_user == head_official and forloop.last %}
-        <li>{{ league }} has no members</li>
-    {% else %}
-    {% if sh_user not in list_of_officials %}
         <li> {{ sh_user }}
             <form id="promote_form" method="POST" action="{% url "manage_league" league.id %}">
             {% csrf_token %}
             <input type="submit" name="promote_{{ sh_user.id }}" value="Promote"/>
             </form>
         </li>
-    {% endif %}
-    {% endif %}
+    {% empty %}
+        <li>{{ league }} has no members</li>
     {% endfor %}
     </ul>
 {% endblock %}

--- a/sh_app/urls.py
+++ b/sh_app/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     url(r'^leagues/create/$', views.create_league, name='create_league'),
     url(r'^leagues/(?P<league_id>[0-9]+)/$', views.league_detail, name='league_detail'),
     url(r'^leagues/(?P<league_id>[0-9]+)/create_suggestion/$', views.create_suggestion, name='create_suggestion'),
-    url(r'^leagues/(?P<league_id>[0-9]+)/manage_league$', views.manage_league, name='manage_league'),
+    url(r'^leagues/(?P<league_id>[0-9]+)/manage_league/$', views.manage_league, name='manage_league'),
     url(r'^suggestion/(?P<suggestion_id>[0-9]+)/$', views.suggestion_detail, name='suggestion_detail'),
 ]

--- a/sh_app/views.py
+++ b/sh_app/views.py
@@ -253,14 +253,13 @@ def manage_league(request, league_id):
                     league.officials.add(target_user)
                     league.save()
 
-        list_of_members = league.members.all()
-        list_of_officials = league.officials.all()
-        head_official = league.head_official
+        list_of_officials = set(league.officials.all()) - set([sh_user])
+        list_of_members = set(league.members.all()) - list_of_officials - set([sh_user])
         return render(request, 'manage_league.html',
                       {'league': league,
                        'list_of_members': list_of_members,
                        'list_of_officials': list_of_officials,
-                       'head_official': head_official})
+                       'head_official': sh_user})
     else:
         # User is not a head official
         return HttpResponse("You must be a head official of league {} to view this page".format(league.name))


### PR DESCRIPTION
Originally, the manage league template had loop conditions to separate head officials, officials, and members. Now the manage league view, as opposed to the template, does the separating. The separating is done using set operations.
